### PR TITLE
Compare policy issuer with token iss claim

### DIFF
--- a/lib/fiware/ishare/ishare_handler.lua
+++ b/lib/fiware/ishare/ishare_handler.lua
@@ -162,6 +162,11 @@ function _M.handle_ngsi_request(config, dict)
       else
 	       return "User policy could not be found in JWT"
       end
+
+      -- Check that policy issuer equals the token issuer to prevent faking another issuer
+      if user_policy_issuer ~= decoded_payload["iss"] then
+	 return "Issuer of the user policy does not match issuer of the provided token"
+      end
    elseif decoded_payload["authorisationRegistry"] and decoded_payload["authorisationRegistry"] ~= cjson.null then
       -- AR info provided in JWT, get user policy from AR
       local token_url = decoded_payload["authorisationRegistry"]["token_endpoint"]
@@ -183,6 +188,11 @@ function _M.handle_ngsi_request(config, dict)
 	       del_notAfter = user_del_evi["notOnOrAfter"]
       else
 	       return "User policy could not be found in user AR response"
+      end
+
+      -- Check that policy issuer equals the token issuer to prevent faking another issuer
+      if user_policy_issuer ~= decoded_payload["iss"] then
+	 return "Issuer of the user policy does not match issuer of the provided token"
       end
    else
       -- Info in JWT missing, assuming M2M

--- a/spec/mock/policies.lua
+++ b/spec/mock/policies.lua
@@ -509,4 +509,42 @@ _M.user.all_attrs_single_id = {
 }
 _M.user.all_attrs_single_id.policySets[1].policies[1].target.resource.type = "DELIVERYORDER"
 
+-- User policy - All actions, all attrs, fake issuer
+_M.user.all_attrs_fake_iss = {
+   notBefore = valid_from,
+   notOnOrAfter = valid_until,
+   policyIssuer = certs.client.identifier_alt,
+   target = {
+      accessSubject = certs.user.identifier
+   },
+   policySets = {
+      {
+	 policies = {
+	    {
+	       target = {
+		  resource = {
+		     --type = "DELIVERYORDER",
+		     identifiers = {
+			"*"
+		     },
+		     attributes = {
+			"*"
+		     }
+		  },
+		  actions = {
+		     "PATCH", "GET", "POST", "DELETE"
+		  }
+	       },
+	       rules = {
+		  {
+		     effect = "Permit"
+		  }
+	       }
+	    }
+	 }
+      }
+   }
+}
+_M.user.all_attrs_fake_iss.policySets[1].policies[1].target.resource.type = "DELIVERYORDER"
+
 return _M


### PR DESCRIPTION
Add check for H2M that policy issuer equals the token issuer to prevent faking another issuer